### PR TITLE
Allow custom screenshot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,19 @@ The default window size for the renders is 1024 x 768 pixels.  You can specify a
        config.page_size = [1280, 1024]
      end
 
-Note that this specifies the size of the browser window viewport; but rspec-page-regression requests a render of the full page, which might extend beyond the window.  So the rendered file dimensions may be larger than this configuration value.
+Note that this specifies the size of the browser window viewport. By default, rspec-page-regression requests a render of the full page, which might extend beyond the window, so the rendered file dimensions may be larger than this configuration value. You can configure this behaviour (see Screenshot options).
+
+### Screenshot options
+
+You can specify the options for the screenshot call issued to Poltergeist. By default, rspec-page-regression requests a render of the full page: `{ :full => true }`.
+
+For instance, you can specify a CSS selector to render a specific element:
+
+  RSpec::PageRegression.configure do |config|
+    config.screenshot_options = { :selector => '#foo' }
+  end
+
+In PhantomJS 2.0, the `full` screenshot option is not working correctly. You can use the `selector` option to work around this issue by passing a selector for an element that covers the whole page.
 
 ### Image difference threshold
 

--- a/lib/rspec/page-regression.rb
+++ b/lib/rspec/page-regression.rb
@@ -24,4 +24,12 @@ module RSpec::PageRegression
   def self.threshold
     @@threshold ||= 0.0
   end
+
+  def self.screenshot_options= options
+    @@screenshot_options = options
+  end
+
+  def self.screenshot_options
+    @@screenshot_options ||= { :full => true }
+  end
 end

--- a/lib/rspec/page-regression/renderer.rb
+++ b/lib/rspec/page-regression/renderer.rb
@@ -7,10 +7,10 @@ module RSpec::PageRegression
       # Capybara doesn't implement resize in API
       unless page.driver.respond_to? :resize
         page.driver.browser.manage.window.resize_to *RSpec::PageRegression.page_size
-      else 
+      else
         page.driver.resize *RSpec::PageRegression.page_size
       end
-      page.driver.save_screenshot test_image_path, :full => true
+      page.driver.save_screenshot test_image_path, RSpec::PageRegression.screenshot_options
     end
   end
 end

--- a/spec/match_expectation_spec.rb
+++ b/spec/match_expectation_spec.rb
@@ -155,6 +155,15 @@ describe "match_expectation" do
       Then { expect(@error.message).to include "Missing expectation image spec/expectation/parent/expected.png" }
     end
 
+    context "with custom screenshot options" do
+      Given do
+        RSpec::PageRegression.configure do |config|
+          config.screenshot_options = { :selector => '#foo' }
+        end
+      end
+      Then { expect(@driver).to have_received(:save_screenshot).with(test_path, { :selector => '#foo' }) }
+    end
+
     context "with page size configuration" do
       Given do
         RSpec::PageRegression.configure do |config|


### PR DESCRIPTION
When using Poltergeist with PhantomJS 2.0, `save_screenshot({:full => true})` doesn't seem to work correctly – the screenshot size is the viewport size, not the page size.

Custom options for the `save_screenshot` allow working around this issue by using Poltergeist's `selector` option. It might also be useful for other cases, e.g. not using the `full` option.
