### PR TITLE
Test on multiple view ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Everything will work normally, and the failure messages will refer to your path.
 
 The default window size for the renders is 1024 x 768 pixels.  You can specify another size as `[height, width]` in pixels:
 
-     # in spec_helper.rb:
-     RSpec::PageRegression.configure do |config|
-       config.page_size = [1280, 1024]
-     end
+    # in spec_helper.rb:
+    RSpec::PageRegression.configure do |config|
+      config.page_size = [[1280, 1024], [1024, 768], [480, 320]]
+    end
 
 Note that this specifies the size of the browser window viewport; but rspec-page-regression requests a render of the full page, which might extend beyond the window.  So the rendered file dimensions may be larger than this configuration value.
 

--- a/lib/rspec/page-regression.rb
+++ b/lib/rspec/page-regression.rb
@@ -14,7 +14,7 @@ module RSpec::PageRegression
   end
 
   def self.page_size
-    @@page_size ||= [1024, 768]
+    @@page_size ||= [[1024, 768]]
   end
 
   def self.threshold= (threshold)

--- a/lib/rspec/page-regression/file_paths.rb
+++ b/lib/rspec/page-regression/file_paths.rb
@@ -5,8 +5,9 @@ module RSpec::PageRegression
     attr_reader :expected_image
     attr_reader :test_image
     attr_reader :difference_image
+    attr_reader :page_size
 
-    def initialize(example, expected_path = nil)
+    def initialize(example, page_size, expected_path = nil)
       expected_path = Pathname.new(expected_path) if expected_path
 
       descriptions = description_ancestry(example.metadata[:example_group])
@@ -25,13 +26,20 @@ module RSpec::PageRegression
       test_root = app_root + "tmp" + "spec" + "expectation"
       cwd = Pathname.getwd
 
-      @expected_image = expected_path || (expected_root + canonical_path + "expected.png").relative_path_from(cwd)
-      @test_image = (test_root + canonical_path + "test.png").relative_path_from cwd
-      @difference_image = (test_root + canonical_path + "difference.png").relative_path_from cwd
+      @page_size = page_size
+      @expected_image = expected_path || (expected_root + canonical_path + "expected-#{page_size.join('x')}.png").relative_path_from(cwd)
+      @test_image = (test_root + canonical_path + "test-#{page_size.join('x')}.png").relative_path_from cwd
+      @difference_image = (test_root + canonical_path + "difference-#{page_size.join('x')}.png").relative_path_from cwd
     end
 
     def all
       [test_image, expected_image, difference_image]
+    end
+
+    def self.responsive_file_paths(example, expected_path = nil)
+      RSpec::PageRegression.page_size.map do |page_size|
+        new(example, page_size, expected_path)
+      end
     end
 
 

--- a/lib/rspec/page-regression/file_paths.rb
+++ b/lib/rspec/page-regression/file_paths.rb
@@ -27,9 +27,9 @@ module RSpec::PageRegression
       cwd = Pathname.getwd
 
       @page_size = page_size
-      @expected_image = expected_path || (expected_root + canonical_path + "expected-#{page_size.join('x')}.png").relative_path_from(cwd)
-      @test_image = (test_root + canonical_path + "test-#{page_size.join('x')}.png").relative_path_from cwd
-      @difference_image = (test_root + canonical_path + "difference-#{page_size.join('x')}.png").relative_path_from cwd
+      @expected_image = expected_path || (expected_root + canonical_path + file_name('expected')).relative_path_from(cwd)
+      @test_image = (test_root + canonical_path + file_name('test')).relative_path_from cwd
+      @difference_image = (test_root + canonical_path + file_name('difference')).relative_path_from cwd
     end
 
     def all
@@ -44,6 +44,10 @@ module RSpec::PageRegression
 
 
     private
+
+    def file_name(prefix)
+      "#{prefix}-#{@page_size.join('x')}.png"
+    end
 
     def description_ancestry(metadata)
       return [] if metadata.nil?

--- a/lib/rspec/page-regression/image_comparison.rb
+++ b/lib/rspec/page-regression/image_comparison.rb
@@ -10,6 +10,7 @@ module RSpec::PageRegression
     include ChunkyPNG::Color
 
     attr_reader :result
+    attr_reader :filepaths
 
     def initialize(filepaths)
       @filepaths = filepaths

--- a/lib/rspec/page-regression/matcher.rb
+++ b/lib/rspec/page-regression/matcher.rb
@@ -8,34 +8,38 @@ module RSpec::PageRegression
       @responsive_filepaths = FilePaths.responsive_file_paths(RSpec.current_example, expectation_path)
       @filepaths = @responsive_filepaths.first
       Renderer.render_responsive(page, @responsive_filepaths)
-      @comparison = ImageComparison.new(@filepaths)
-      @comparison.result == :match
+      @comparisons = @responsive_filepaths.map{ |filepaths| ImageComparison.new(filepaths) }
+      @comparisons.each { |comparison| return false unless comparison.result == :match }
     end
 
     failure_message do |page|
-      msg = case @comparison.result
-            when :missing_expected then "Missing expectation image #{@filepaths.expected_image}"
-            when :missing_test then "Missing test image #{@filepaths.test_image}"
-            when :size_mismatch then "Test image size #{@comparison.test_size.join('x')} does not match expectation #{@comparison.expected_size.join('x')}"
-            when :difference then "Test image does not match expected image"
-            end
+      msg = ''
+      @comparisons.each do |comparison|
+        next if comparison.result == :match
+        msg +=  case comparison.result
+                  when :missing_expected then "\nMissing expectation image #{comparison.filepaths.expected_image}"
+                  when :missing_test then "Missing test image #{comparison.filepaths.test_image}"
+                  when :size_mismatch then "Test image size #{comparison.test_size.join('x')} does not match expectation #{comparison.expected_size.join('x')}"
+                  when :difference then 'Test image does not match expected image'
+                end
 
-      msg += "\n    $ #{viewer} #{@filepaths.all.select(&:exist?).join(' ')}"
+        msg += "\n    $ #{viewer} #{comparison.filepaths.all.select(&:exist?).join(' ')}"
 
-      case @comparison.result
-      when :missing_expected
-        msg += "\nCreate it via:\n    $ mkdir -p #{@filepaths.expected_image.dirname} && cp #{@filepaths.test_image} #{@filepaths.expected_image}"
+        case comparison.result
+        when :missing_expected
+          msg += "\nCreate it via:\n    $ mkdir -p #{comparison.filepaths.expected_image.dirname} && cp #{comparison.filepaths.test_image} #{comparison.filepaths.expected_image}\n\n"
+        end
       end
 
       msg
     end
 
     failure_message_when_negated do |page|
-      "Test image expected to not match expectation image"
+      'Test image expected to not match expectation image'
     end
 
     def viewer
-      File.basename(Which.which("open", "feh", "display", :array => true).first || "viewer")
+      File.basename(Which.which('open', 'feh', 'display', array: true).first || 'viewer')
     end
   end
 end

--- a/lib/rspec/page-regression/matcher.rb
+++ b/lib/rspec/page-regression/matcher.rb
@@ -5,8 +5,9 @@ module RSpec::PageRegression
   RSpec::Matchers.define :match_expectation do |expectation_path|
 
     match do |page|
-      @filepaths = FilePaths.new(RSpec.current_example, expectation_path)
-      Renderer.render(page, @filepaths.test_image)
+      @responsive_filepaths = FilePaths.responsive_file_paths(RSpec.current_example, expectation_path)
+      @filepaths = @responsive_filepaths.first
+      Renderer.render_responsive(page, @responsive_filepaths)
       @comparison = ImageComparison.new(@filepaths)
       @comparison.result == :match
     end

--- a/lib/rspec/page-regression/matcher.rb
+++ b/lib/rspec/page-regression/matcher.rb
@@ -6,7 +6,6 @@ module RSpec::PageRegression
 
     match do |page|
       @responsive_filepaths = FilePaths.responsive_file_paths(RSpec.current_example, expectation_path)
-      @filepaths = @responsive_filepaths.first
       Renderer.render_responsive(page, @responsive_filepaths)
       @comparisons = @responsive_filepaths.map{ |filepaths| ImageComparison.new(filepaths) }
       @comparisons.each { |comparison| return false unless comparison.result == :match }

--- a/lib/rspec/page-regression/renderer.rb
+++ b/lib/rspec/page-regression/renderer.rb
@@ -1,16 +1,20 @@
 module RSpec::PageRegression
   module Renderer
 
-    def self.render(page, test_image_path)
-
+    def self.render(page, filepaths)
+      test_image_path = filepaths.test_image
       test_image_path.dirname.mkpath unless test_image_path.dirname.exist?
       # Capybara doesn't implement resize in API
       unless page.driver.respond_to? :resize
-        page.driver.browser.manage.window.resize_to *RSpec::PageRegression.page_size
-      else 
-        page.driver.resize *RSpec::PageRegression.page_size
+        page.driver.browser.manage.window.resize_to *filepaths.page_size
+      else
+        page.driver.resize *filepaths.page_size
       end
-      page.driver.save_screenshot test_image_path, :full => true
+      page.driver.save_screenshot test_image_path, full: true
+    end
+
+    def self.render_responsive(page, responsive_filepaths)
+      responsive_filepaths.each { |fp| render(page, fp) }
     end
   end
 end

--- a/spec/match_expectation_spec.rb
+++ b/spec/match_expectation_spec.rb
@@ -173,6 +173,51 @@ describe "match_expectation" do
       Then { expect(@driver).to have_received(:resize).with(123, 456) }
     end
 
+    context "with multiple page size configuration" do
+      Given do
+        RSpec::PageRegression.configure do |config|
+          config.page_size = [[1024, 768], [480, 320]]
+        end
+
+        use_test_image('A', [1024, 768])
+        use_test_image('A', [480, 320])
+      end
+
+      context 'should receive 2 resizes' do
+        Then { expect(@driver).to have_received(:resize).with(1024, 768) }
+        Then { expect(@driver).to have_received(:resize).with(480, 320) }
+      end
+
+      context 'fails when all the expected files are missing' do
+        Then { expect(@error.message).to include "Missing expectation image #{expected_path([1024, 768])}" }
+        Then { expect(@error.message).to include "Missing expectation image #{expected_path([480, 320])}" }
+      end
+
+      context 'fails when one of the expected files are missing' do
+        Given { use_expected_image('A', [1024, 768]) }
+        Then { expect(@error.message).to_not include "Missing expectation image #{expected_path([1024, 768])}" }
+        Then { expect(@error.message).to include "Missing expectation image #{expected_path([480, 320])}" }
+      end
+
+      context 'passes when expectation matches in all page sizes' do
+        Given do
+          use_expected_image('A', [1024, 768])
+          use_expected_image('A', [480, 320])
+        end
+        Then { expect(@error).to be_nil }
+      end
+
+      context 'fails when expectation does not match atleast one of the page sizes' do
+        Given do
+          use_expected_image('A', [1024, 768])
+          use_expected_image('B', [480, 320])
+        end
+        Then { expect(@error.message).to include "Test image does not match expected image" }
+        Then { expect(@error.message).to include "#{expected_path([480, 320])}" }
+        Then { expect(@error.message).to_not include "#{expected_path([1024, 768])}" }
+      end
+    end
+
   end
 
   context "using expect().to_not" do
@@ -212,12 +257,12 @@ describe "match_expectation" do
   def create_existing_difference_image
   end
 
-  def use_test_image(name)
-    use_fixture_image(name, test_path)
+  def use_test_image(name, page_size = nil)
+    use_fixture_image(name, test_path(page_size))
   end
 
-  def use_expected_image(name)
-    use_fixture_image(name, expected_path)
+  def use_expected_image(name, page_size = nil)
+    use_fixture_image(name, expected_path(page_size))
   end
 
   def preexisting_difference_image

--- a/spec/match_expectation_spec.rb
+++ b/spec/match_expectation_spec.rb
@@ -15,9 +15,9 @@ describe "match_expectation" do
 
   context "helpers" do
     it "use proper paths" do
-      expect(expected_path).to eq Pathname.new("spec/expectation/match_expectation/helpers/use_proper_paths/expected.png")
-      expect(test_path).to eq Pathname.new("tmp/spec/expectation/match_expectation/helpers/use_proper_paths/test.png")
-      expect(difference_path).to eq Pathname.new("tmp/spec/expectation/match_expectation/helpers/use_proper_paths/difference.png")
+      expect(expected_path).to eq Pathname.new("spec/expectation/match_expectation/helpers/use_proper_paths/#{file_name('expected')}.png")
+      expect(test_path).to eq Pathname.new("tmp/spec/expectation/match_expectation/helpers/use_proper_paths/#{file_name('test')}.png")
+      expect(difference_path).to eq Pathname.new("tmp/spec/expectation/match_expectation/helpers/use_proper_paths/#{file_name('difference')}.png")
     end
   end
 
@@ -160,14 +160,14 @@ describe "match_expectation" do
           example_group: { description: "parent" }
         }
       end
-      Then { expect(@driver).to have_received(:save_screenshot).with(Pathname.new("tmp/spec/expectation/parent/test.png"), @opts) }
-      Then { expect(@error.message).to include "Missing expectation image spec/expectation/parent/expected.png" }
+      Then { expect(@driver).to have_received(:save_screenshot).with(Pathname.new("tmp/spec/expectation/parent/#{file_name('test')}.png"), @opts) }
+      Then { expect(@error.message).to include "Missing expectation image spec/expectation/parent/expected" }
     end
 
     context "with page size configuration" do
       Given do
         RSpec::PageRegression.configure do |config|
-          config.page_size = [123, 456]
+          config.page_size = [[123, 456]]
         end
       end
       Then { expect(@driver).to have_received(:resize).with(123, 456) }

--- a/spec/match_expectation_spec.rb
+++ b/spec/match_expectation_spec.rb
@@ -170,6 +170,13 @@ describe "match_expectation" do
           config.page_size = [[123, 456]]
         end
       end
+
+      after :each do
+        RSpec::PageRegression.configure do |config|
+          config.page_size = [[1024, 768]]
+        end
+      end
+
       Then { expect(@driver).to have_received(:resize).with(123, 456) }
     end
 
@@ -181,6 +188,12 @@ describe "match_expectation" do
 
         use_test_image('A', [1024, 768])
         use_test_image('A', [480, 320])
+      end
+
+      after :each do
+        RSpec::PageRegression.configure do |config|
+          config.page_size = [[1024, 768]]
+        end
       end
 
       context 'should receive 2 resizes' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,15 +1,15 @@
 module Helpers
 
-  def test_path
-    getpath(TestDir, file_name('test'))
+  def test_path(page_size = nil)
+    getpath(TestDir, file_name('test', page_size))
   end
 
-  def expected_path
-    getpath(SpecDir, file_name('expected'))
+  def expected_path(page_size = nil)
+    getpath(SpecDir, file_name('expected', page_size))
   end
 
-  def difference_path
-    getpath(TestDir, file_name('difference'))
+  def difference_path(page_size = nil)
+    getpath(TestDir, file_name('difference', page_size))
   end
 
   def getpath(root, base)
@@ -25,8 +25,9 @@ module Helpers
     group_path(metadata[:parent_example_group]) + metadata[:description].parameterize("_")
   end
 
-  def file_name(prefix)
-    "#{prefix}-#{RSpec::PageRegression.page_size.first.join('x')}"
+  def file_name(prefix, page_size = nil)
+    page_size ||= RSpec::PageRegression.page_size.first
+    "#{prefix}-#{page_size.join('x')}"
   end
 
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,15 +1,15 @@
 module Helpers
 
   def test_path
-    getpath(TestDir, "test")
+    getpath(TestDir, file_name('test'))
   end
 
   def expected_path
-    getpath(SpecDir, "expected")
+    getpath(SpecDir, file_name('expected'))
   end
 
   def difference_path
-    getpath(TestDir, "difference")
+    getpath(TestDir, file_name('difference'))
   end
 
   def getpath(root, base)
@@ -23,6 +23,10 @@ module Helpers
   def group_path(metadata)
     return Pathname.new("") if metadata.nil?
     group_path(metadata[:parent_example_group]) + metadata[:description].parameterize("_")
+  end
+
+  def file_name(prefix)
+    "#{prefix}-#{RSpec::PageRegression.page_size.first.join('x')}"
   end
 
 end


### PR DESCRIPTION
@ronen 
I am using your gem for some of my projects and I really wanted it to be able to test responsive design on multiple viewports. I have done a quick fix for the same purpose and it works for me :smile: 

I thought I'll share what I have done especially when there is already a request for similar feature (https://github.com/ronen/rspec-page-regression/issues/11).

```ruby
###
# The gem now generates files with size appended to the name:
# test-1024x768.png
# expected-1024x768.png
# difference-1024x768.png
 
# test-480x320.png
# expected-480x320.png
# difference-480x320.png

# And can be configured by specifying the sizes in an array:
# in spec_helper.rb:
RSpec::PageRegression.configure do |config|
  config.page_size = [[1024, 768], [480, 320]]
end

```
I am open to your feedback and suggestions.:)

Thanks.