### PR TITLE
Render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ It also shows a "difference image" in which each pixel contains the per-channel 
 
 **Note** Read [CONFIGURATION](#configuration) section for more.
 
+### May I match a part of a page?
+
+You can use `selector` option to specify area to match: 
+
+```ruby
+    require 'spec_helper'
+
+    describe "my page", :type => :feature, :js => true do
+
+      before(:each) do
+        visit my_page_path
+      end
+
+      it { expect(page).to match_reference_screenshot(selector: '#foo') }
+    end
+```
+
 ### How do I create reference screenshots?
 
 The easiest way to create a reference screenshot is to run the test for the first time and let it fail.  You'll then get a failure message like:

--- a/lib/rspec/page-regression.rb
+++ b/lib/rspec/page-regression.rb
@@ -6,7 +6,7 @@ require 'rspec/page-regression/version'
 require 'rspec/page-regression/viewport'
 
 module RSpec::PageRegression
-  ALLOWED_ARGS = [:viewport, :except_viewport]
+  ALLOWED_ARGS = [:viewport, :except_viewport, :selector]
 
   def self.configure
     yield self

--- a/lib/rspec/page-regression.rb
+++ b/lib/rspec/page-regression.rb
@@ -6,7 +6,8 @@ require 'rspec/page-regression/version'
 require 'rspec/page-regression/viewport'
 
 module RSpec::PageRegression
-  ALLOWED_ARGS = [:viewport, :except_viewport, :selector]
+  RENDER_ARGS = [:selector, :full]
+  ALLOWED_ARGS = [:viewport, :except_viewport] + RENDER_ARGS
 
   def self.configure
     yield self

--- a/lib/rspec/page-regression/matcher.rb
+++ b/lib/rspec/page-regression/matcher.rb
@@ -8,11 +8,7 @@ module RSpec::PageRegression
       verify_arguments(args)
       @responsive_filepaths = FilePaths.responsive_file_paths(RSpec.current_example, args)
 
-      if args.key?(:selector)
-        opt = { selector: args[:selector] }
-      else
-        opt = { full: args.fetch(:full, true) }
-      end
+      opt = args.select { |k,_| RENDER_ARGS.include?(k) }
 
       Renderer.render_responsive(page, @responsive_filepaths, opt)
       @comparisons = @responsive_filepaths.map{ |filepaths| ImageComparison.new(filepaths) }

--- a/lib/rspec/page-regression/matcher.rb
+++ b/lib/rspec/page-regression/matcher.rb
@@ -7,7 +7,14 @@ module RSpec::PageRegression
       args ||= {}
       verify_arguments(args)
       @responsive_filepaths = FilePaths.responsive_file_paths(RSpec.current_example, args)
-      Renderer.render_responsive(page, @responsive_filepaths)
+
+      if args.key?(:selector)
+        opt = { selector: args[:selector] }
+      else
+        opt = { full: args.fetch(:full, true) }
+      end
+
+      Renderer.render_responsive(page, @responsive_filepaths, opt)
       @comparisons = @responsive_filepaths.map{ |filepaths| ImageComparison.new(filepaths) }
       @comparisons.each { |comparison| return false unless comparison.result == :match }
     end

--- a/lib/rspec/page-regression/renderer.rb
+++ b/lib/rspec/page-regression/renderer.rb
@@ -1,7 +1,7 @@
 module RSpec::PageRegression
   module Renderer
 
-    def self.render(page, filepaths)
+    def self.render(page, filepaths, options = {})
       test_screenshot_path = filepaths.test_screenshot
       test_screenshot_path.dirname.mkpath unless test_screenshot_path.dirname.exist?
       # Capybara doesn't implement resize in API
@@ -10,11 +10,12 @@ module RSpec::PageRegression
       else
         page.driver.resize *filepaths.viewport.size
       end
-      page.driver.save_screenshot test_screenshot_path, full: true
+      options[:full] = true unless options.key?(:selector)
+      page.driver.save_screenshot test_screenshot_path, options
     end
 
-    def self.render_responsive(page, responsive_filepaths)
-      responsive_filepaths.each { |fp| render(page, fp) }
+    def self.render_responsive(page, responsive_filepaths, opt)
+      responsive_filepaths.each { |fp| render(page, fp, opt) }
     end
   end
 end

--- a/lib/rspec/page-regression/renderer.rb
+++ b/lib/rspec/page-regression/renderer.rb
@@ -10,7 +10,8 @@ module RSpec::PageRegression
       else
         page.driver.resize *filepaths.viewport.size
       end
-      options[:full] = true unless options.key?(:selector)
+      options = { full: true }.merge(options)
+      options.delete(:full) if options.key?(:selector)
       page.driver.save_screenshot test_screenshot_path, options
     end
 

--- a/spec/match_reference_screenshot_spec.rb
+++ b/spec/match_reference_screenshot_spec.rb
@@ -36,6 +36,12 @@ describe 'match_reference_screenshot' do
       context "without selector" do
         Then { expect(@driver).to have_received(:save_screenshot).with(anything, full: true) }
       end
+
+      context "with full: false" do
+        Given { @args = { full: false } }
+
+        Then { expect(@driver).to have_received(:save_screenshot).with(anything, full: false) }
+      end
     end
 
     context "when files match" do

--- a/spec/match_reference_screenshot_spec.rb
+++ b/spec/match_reference_screenshot_spec.rb
@@ -5,7 +5,8 @@ describe 'match_reference_screenshot' do
   Given { initialize_spec }
 
   context "using expect().to" do
-    When { perform_screenshot_match }
+    Given { @args = nil }
+    When { perform_screenshot_match(@args) }
 
     context "framework" do
       Then { expect(@driver).to have_received(:resize).with(1024, 768) }
@@ -24,6 +25,16 @@ describe 'match_reference_screenshot' do
         }
 
         Then { expect(@window).to have_received(:resize_to).with(1024, 768) }
+      end
+
+      context "with selector" do
+        Given { @args = { selector: "#foo" } }
+
+        Then { expect(@driver).to have_received(:save_screenshot).with(anything, selector: "#foo") }
+      end
+
+      context "without selector" do
+        Then { expect(@driver).to have_received(:save_screenshot).with(anything, full: true) }
       end
     end
 


### PR DESCRIPTION
This PR makes possible to specify matching area thru selector:

``` ruby
expect(page).to match_reference_screenshot(selector: "#foo")
```
