### PR TITLE
Fix dependencies by upgrading ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.1.0
+  - 2.2.2
   - jruby
 script: bundle exec rake spec_with_coveralls

--- a/rspec-page-regression.gemspec
+++ b/rspec-page-regression.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.2.2"
+
   spec.add_dependency "activesupport"
 
   if RUBY_PLATFORM == 'java'


### PR DESCRIPTION
Not sure if this is the best way to fix the build, but it looks like a number of gem dependencies have moved past ruby `2.1.0`. Upgrading to `2.2.2` fixes those dependencies.